### PR TITLE
Added sound on loop feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>me.lavinytuttini</groupId>
   <artifactId>areasoundevents</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
   <packaging>jar</packaging>
 
   <name>AreaSoundEvents</name>

--- a/src/main/java/me/lavinytuttini/areasoundevents/commands/subcommands/CreateCommand.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/commands/subcommands/CreateCommand.java
@@ -55,9 +55,13 @@ public class CreateCommand extends SubCommand {
                 suggestions.add(category.name().toLowerCase());
             }
         } else if (args.length == 5) {
-            suggestions.add("1");
+            suggestions.add("<volume [0.0~1.0]>");
         } else if (args.length == 6) {
-            suggestions.add("1");
+            suggestions.add("<pitch [0.0~1.0]>");
+        } else if (args.length == 7) {
+            suggestions.add("<loop [true/false]>");
+        } else if (args.length == 8) {
+            suggestions.add("<loop-time [Number]>");
         }
 
         return suggestions;
@@ -76,6 +80,8 @@ public class CreateCommand extends SubCommand {
         SoundCategory source = defaultSettings.getDefaultSoundCategory();
         float volume = defaultSettings.getDefaultSoundVolume();
         float pitch = defaultSettings.getDefaultSoundPitch();
+        boolean loop = defaultSettings.isDefaultLoopSound();
+        int loopTime = defaultSettings.getDefaultSoundLoopTime();
 
         if (args.length >= 4) {
             source = Utils.processSoundCategoryArgument(args[3], source);
@@ -83,8 +89,14 @@ public class CreateCommand extends SubCommand {
         if (args.length >= 5) {
             volume = Utils.parseFloatArgument(args[4], volume);
         }
-        if (args.length == 6) {
+        if (args.length >= 6) {
             pitch = Utils.parseFloatArgument(args[5], pitch);
+        }
+        if (args.length >= 7) {
+            loop = Utils.parseBooleanArgument(args[6], loop);
+        }
+        if (args.length == 8) {
+            loopTime = Utils.parseIntegerArgument(args[7], loopTime);
         }
 
         Map<String, RegionData> regionDataMap = regionsSettings.getRegionDataMap();
@@ -92,7 +104,7 @@ public class CreateCommand extends SubCommand {
         if (regionDataMap.containsKey(regionName)) {
             player.sendMessage(ChatColor.RED + localization.getString("commands_create_region_exists", regionName));
         } else {
-            RegionData regionData = new RegionData(regionName, soundName, source, volume, pitch);
+            RegionData regionData = new RegionData(regionName, soundName, source, volume, pitch, loop, loopTime);
             regionDataMap.put(regionData.getName(), regionData);
             regionsSettings.setRegionDataMap(regionDataMap);
 

--- a/src/main/java/me/lavinytuttini/areasoundevents/commands/subcommands/ListCommand.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/commands/subcommands/ListCommand.java
@@ -77,6 +77,8 @@ public class ListCommand extends SubCommand {
         SoundCategory source = regionData.getSource();
         float volume = regionData.getVolume();
         float pitch = regionData.getPitch();
+        boolean loop = regionData.isLoop();
+        int loopTime = regionData.getLoopTime();
 
         ComponentBuilder messageBuilder = new ComponentBuilder();
 
@@ -110,6 +112,14 @@ public class ListCommand extends SubCommand {
                 .color(net.md_5.bungee.api.ChatColor.GREEN)
                 .event(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/areasoundevents modify " + regionName + " pitch="));
 
+        ComponentBuilder loopButtonBuilder = new ComponentBuilder("Loop:")
+                .color(net.md_5.bungee.api.ChatColor.GREEN)
+                .event(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/areasoundevents modify " + regionName + " loop="));
+
+        ComponentBuilder loopTimeButtonBuilder = new ComponentBuilder("LoopTime:")
+                .color(net.md_5.bungee.api.ChatColor.GREEN)
+                .event(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/areasoundevents modify " + regionName + " loopTime="));
+
         messageBuilder.append(regionButtonBuilder.create())
                 .color(net.md_5.bungee.api.ChatColor.GREEN)
                 .append("").reset()
@@ -120,7 +130,9 @@ public class ListCommand extends SubCommand {
         messageBuilder.append(ChatColor.GREEN + " | ").append(soundButtonBuilder.create()).append("").reset().append(ChatColor.WHITE + " " + soundName + "\n");
         messageBuilder.append(ChatColor.GREEN + " | ").append(sourceButtonBuilder.create()).append("").reset().append(ChatColor.WHITE + " " + source + "\n");
         messageBuilder.append(ChatColor.GREEN + " | ").append(volumeButtonBuilder.create()).append("").reset().append(ChatColor.WHITE + " " + volume + "\n");
-        messageBuilder.append(ChatColor.GREEN + " | ").append(pitchButtonBuilder.create()).append("").reset().append(ChatColor.WHITE + " " + pitch);
+        messageBuilder.append(ChatColor.GREEN + " | ").append(pitchButtonBuilder.create()).append("").reset().append(ChatColor.WHITE + " " + pitch + "\n");
+        messageBuilder.append(ChatColor.GREEN + " | ").append(loopButtonBuilder.create()).append("").reset().append(ChatColor.WHITE + " " + loop + "\n");
+        messageBuilder.append(ChatColor.GREEN + " | ").append(loopTimeButtonBuilder.create()).append("").reset().append(ChatColor.WHITE + " " + loopTime);
 
         return messageBuilder.create();
     }

--- a/src/main/java/me/lavinytuttini/areasoundevents/commands/subcommands/ModifyCommand.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/commands/subcommands/ModifyCommand.java
@@ -141,6 +141,26 @@ public class ModifyCommand extends SubCommand {
                             invalidArguments.add(args[i]);
                         }
                         break;
+                    case "loop":
+                        try {
+                            String loop = argParts[1];
+                            if (loop.equals("false") || loop.equals("true")) {
+                                regionData.setLoop(Boolean.parseBoolean(args[i]));
+                            } else {
+                                invalidArguments.add(args[i]);
+                            }
+                        } catch (NumberFormatException | NullPointerException e) {
+                            invalidArguments.add(args[i]);
+                        }
+                        break;
+                    case "loopTime":
+                        try {
+                            int loopTime = Integer.parseInt(argParts[1]);
+                            regionData.setLoopTime(loopTime);
+                        } catch (NumberFormatException e) {
+                            invalidArguments.add(args[i]);
+                        }
+                        break;
                     default:
                         invalidArguments.add(args[i]);
                         break;

--- a/src/main/java/me/lavinytuttini/areasoundevents/data/RegionData.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/data/RegionData.java
@@ -8,13 +8,17 @@ public class RegionData {
     private SoundCategory source;
     private float volume;
     private float pitch;
+    private boolean loop;
+    private int loopTime;
 
-    public RegionData(String name, String sound, SoundCategory source, float volume, float pitch) {
+    public RegionData(String name, String sound, SoundCategory source, float volume, float pitch, boolean loop, int loopTime) {
         this.name = name;
         this.sound = sound;
         this.source = source;
         this.volume = volume;
         this.pitch = pitch;
+        this.loop = loop;
+        this.loopTime = loopTime;
     }
 
     public String getName() {
@@ -55,5 +59,21 @@ public class RegionData {
 
     public void setPitch(float pitch) {
         this.pitch = pitch;
+    }
+
+    public boolean isLoop() {
+        return loop;
+    }
+
+    public void setLoop(boolean loop) {
+        this.loop = loop;
+    }
+
+    public int getLoopTime() {
+        return loopTime;
+    }
+
+    public void setLoopTime(int loopTime) {
+        this.loopTime = loopTime;
     }
 }

--- a/src/main/java/me/lavinytuttini/areasoundevents/data/config/DefaultSettings.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/data/config/DefaultSettings.java
@@ -9,6 +9,8 @@ public class DefaultSettings {
     private int defaultEnterCooldown;
     private int defaultLeaveCooldown;
     private int defaultListPageSize;
+    private boolean defaultLoopSound;
+    private int defaultSoundLoopTime;
 
     public SoundCategory getDefaultSoundCategory() {
         return defaultSoundCategory;
@@ -56,5 +58,21 @@ public class DefaultSettings {
 
     public void setDefaultListPageSize(int defaultListPageSize) {
         this.defaultListPageSize = defaultListPageSize;
+    }
+
+    public boolean isDefaultLoopSound() {
+        return defaultLoopSound;
+    }
+
+    public void setDefaultLoopSound(boolean defaultLoopSound) {
+        this.defaultLoopSound = defaultLoopSound;
+    }
+
+    public int getDefaultSoundLoopTime() {
+        return defaultSoundLoopTime;
+    }
+
+    public void setDefaultSoundLoopTime(int defaultSoundLoopTime) {
+        this.defaultSoundLoopTime = defaultSoundLoopTime;
     }
 }

--- a/src/main/java/me/lavinytuttini/areasoundevents/listeners/PlayerListeners.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/listeners/PlayerListeners.java
@@ -3,7 +3,6 @@ package me.lavinytuttini.areasoundevents.listeners;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.bukkit.listener.PlayerMoveListener;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
@@ -12,8 +11,6 @@ import com.sk89q.worldguard.protection.regions.RegionQuery;
 import me.lavinytuttini.areasoundevents.AreaSoundEvents;
 import me.lavinytuttini.areasoundevents.data.PlayerData;
 import me.lavinytuttini.areasoundevents.data.RegionData;
-import me.lavinytuttini.areasoundevents.data.config.DefaultSettings;
-import me.lavinytuttini.areasoundevents.data.config.MainSettings;
 import me.lavinytuttini.areasoundevents.managers.LocalizationManager;
 import me.lavinytuttini.areasoundevents.settings.ConfigSettings;
 import me.lavinytuttini.areasoundevents.settings.RegionsSettings;
@@ -24,17 +21,22 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 
 import static org.bukkit.Bukkit.getLogger;
 
 public class PlayerListeners implements Listener {
     AreaSoundEvents areaSoundEvents = AreaSoundEvents.getInstance();
     private final ArrayList<Player> left = new ArrayList<>();
-    private final Map<Player, PlayerData> entered = new HashMap<>();
+    private final Map<Player, PlayerData> entered = new ConcurrentHashMap<>();
+    private final Map<UUID, BukkitTask> runningTasks = new ConcurrentHashMap<>();
     private final ConfigSettings configSettings = ConfigSettings.getInstance();
     private final LocalizationManager localization = LocalizationManager.getInstance();
 
@@ -51,13 +53,21 @@ public class PlayerListeners implements Listener {
     @EventHandler
     public void joinEvent(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        enterRegion(player);
+        try {
+            enterRegion(player);
+        } catch (Exception e) {
+            getLogger().log(Level.SEVERE, "Error handling region entry for player " + player.getName(), e);
+        }
     }
 
     @EventHandler
     public void moveEvent(PlayerMoveEvent event) {
         Player player = event.getPlayer();
-        enterRegion(player);
+        try {
+            enterRegion(player);
+        } catch (Exception e) {
+            getLogger().log(Level.SEVERE, "Error handling region entry for player " + player.getName(), e);
+        }
     }
 
     public void enterRegion(Player player) {
@@ -67,9 +77,9 @@ public class PlayerListeners implements Listener {
         RegionQuery query = container.createQuery();
         ApplicableRegionSet applicableRegionSet = query.getApplicableRegions(BukkitAdapter.adapt(playerLocation));
 
-        for (ProtectedRegion regions : applicableRegionSet) {
-            if (regions.contains(playerLocation.getBlockX(), playerLocation.getBlockY(), playerLocation.getBlockZ())) {
-                if (!entered.containsKey(player)) {
+        if (!entered.containsKey(player)) {
+            for (ProtectedRegion regions : applicableRegionSet) {
+                if (regions.contains(playerLocation.getBlockX(), playerLocation.getBlockY(), playerLocation.getBlockZ())) {
                     try {
                         String regionId = regions.getId();
                         StateFlag.State state = regions.getFlag(AreaSoundEvents.AREA_SOUND_EVENTS_FLAG);
@@ -82,10 +92,18 @@ public class PlayerListeners implements Listener {
                                 left.remove(player);
                                 entered.put(player, playerData);
 
-                                player.stopAllSounds(); // TODO: Only allowed from v1.17.1
-                                // player.stopSound(regionData.getSource()); TODO: Send SoundCategory is only allowed in stopSound method from v1.19.1
-                                // TODO: Create looping sound: Use considerable tasks as playing a sound repeatedly can consume server resources -> this.runTaskTimer(areaSoundEvents.getInstance(), 0L, 20L);
-                                player.playSound(player.getLocation(), regionData.getSound(), regionData.getSource(), regionData.getVolume(), regionData.getPitch());
+                                if (regionData.isLoop()) {
+                                    BukkitTask soundTask = runningTasks.get(player.getUniqueId());
+                                    if (soundTask == null || soundTask.isCancelled()) {
+                                        soundTask = createLoopingSoundTask(player, regionData);
+                                        runningTasks.put(player.getUniqueId(), soundTask);
+                                    }
+                                } else {
+                                    player.stopAllSounds(); // TODO: Only allowed from v1.17.1
+                                    // player.stopSound(regionData.getSource()); TODO: Send SoundCategory is only allowed in stopSound method from v1.19.1
+                                    // TODO: Create looping sound: Use considerable tasks as playing a sound repeatedly can consume server resources -> this.runTaskTimer(areaSoundEvents.getInstance(), 0L, 20L);
+                                    player.playSound(player.getLocation(), regionData.getSound(), regionData.getSource(), regionData.getVolume(), regionData.getPitch());
+                                }
 
                                 if (!configSettings.getMainSettings().isSilentMode()) {
                                     player.sendMessage(ChatColor.GREEN + localization.getString("information_player_enters_region", regionData.getName()));
@@ -94,19 +112,41 @@ public class PlayerListeners implements Listener {
                             }
                         }
                     } catch (Exception e) {
-                        getLogger().severe(e.getMessage());
+                        getLogger().severe("Error entering region: " + e.getMessage());
                     }
                 }
             }
         }
 
-        if (!left.contains(player) && entered.get(player) != null) {
+
+        if (!left.contains(player) && entered.get(player) != null && applicableRegionSet.size() == 0) {
             if (applicableRegionSet.size() == 0) {
                 player.stopSound(entered.get(player).getSound(), entered.get(player).getSource());
                 player.sendMessage(ChatColor.RED + localization.getString("information_player_leaves_region", entered.get(player).getRegion()));
+
+                BukkitTask task = runningTasks.remove(player.getUniqueId());
+                if (task != null) {
+                    task.cancel();
+                }
+
                 entered.remove(player);
                 left.add(player);
             }
         }
+    }
+
+    private BukkitTask createLoopingSoundTask(Player player, RegionData regionData) {
+        return new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!player.isOnline()) {
+                    cancel();
+                    return;
+                }
+
+                player.stopAllSounds();
+                player.playSound(player.getLocation(), regionData.getSound(), regionData.getSource(), regionData.getVolume(), regionData.getPitch());
+            }
+        }.runTaskTimerAsynchronously(AreaSoundEvents.getInstance(), 0, regionData.getLoopTime() * 20L);
     }
 }

--- a/src/main/java/me/lavinytuttini/areasoundevents/settings/ConfigSettings.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/settings/ConfigSettings.java
@@ -72,6 +72,8 @@ public class ConfigSettings {
         setConfigValue(config, pathDefaultSettings + "default-leave-cooldown", Integer.class, Integer::parseInt, defaultSettings::setDefaultLeaveCooldown, 0);
         setConfigValue(config, pathDefaultSettings + "default-sound-category", SoundCategory.class, SoundCategory::valueOf, defaultSettings::setDefaultSoundCategory, SoundCategory.MASTER);
         setConfigValue(config, pathDefaultSettings + "default-list-page-size", Integer.class, Integer::parseInt, defaultSettings::setDefaultListPageSize, 2);
+        setConfigValue(config, pathDefaultSettings + "default-loop-sound", Boolean.class, Boolean::parseBoolean, defaultSettings::setDefaultLoopSound, false);
+        setConfigValue(config, pathDefaultSettings + "default-loop-time", Integer.class, Integer::parseInt, defaultSettings::setDefaultSoundLoopTime, 60);
     }
 
     private void loadDefaultSubcommandPermissions(FileConfiguration config) {

--- a/src/main/java/me/lavinytuttini/areasoundevents/settings/RegionsSettings.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/settings/RegionsSettings.java
@@ -87,8 +87,10 @@ public class RegionsSettings {
         SoundCategory source = Utils.getEnumProperty(properties, "source", SoundCategory.class, configSettings.getDefaultSettings().getDefaultSoundCategory());
         float volume = Utils.getFloatProperty(properties, "volume", configSettings.getDefaultSettings().getDefaultSoundVolume());
         float pitch = Utils.getFloatProperty(properties, "pitch", configSettings.getDefaultSettings().getDefaultSoundPitch());
+        boolean loop = Utils.getBooleanProperty(properties, "loop", configSettings.getDefaultSettings().isDefaultLoopSound());
+        int loopTime = Utils.getIntegerProperty(properties, "loopTime", configSettings.getDefaultSettings().getDefaultSoundLoopTime());
 
-        RegionData regionData = new RegionData(regionName, sound, source, volume, pitch);
+        RegionData regionData = new RegionData(regionName, sound, source, volume, pitch, loop, loopTime);
 
         regionDataMap.put(regionName, regionData);
 

--- a/src/main/java/me/lavinytuttini/areasoundevents/utils/Utils.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/utils/Utils.java
@@ -3,13 +3,28 @@ package me.lavinytuttini.areasoundevents.utils;
 import me.lavinytuttini.areasoundevents.AreaSoundEvents;
 import me.lavinytuttini.areasoundevents.managers.MessageManager;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.SoundCategory;
+import org.bukkit.entity.Player;
 
 import java.util.Map;
 
 import static org.bukkit.Bukkit.getLogger;
 
 public class Utils {
+    public static String color(String string) {
+        return ChatColor.translateAlternateColorCodes('&', string);
+    }
+
+    public static String deColor(String string) {
+        return ChatColor.stripColor(color(string));
+    }
+
+    public static void playerMessage(Player player, String... strings) {
+        for (String  string: strings) {
+            player.sendMessage(color(string));
+        }
+    }
 
     public static boolean isServerVersionNewerThan(ServerVersion serverVersion) {
         ServerVersion version = AreaSoundEvents.serverVersion;
@@ -25,16 +40,16 @@ public class Utils {
         return ServerVersion.valueOf(bukkitName.replace("org.bukkit.craftbukkit.", ""));
     }
 
-    public static Float parseFloatArgument(String arg, float defaultValue) {
+    public static Float parseFloatArgument(String argument, float defaultValue) {
         try {
-            float floatArg = Float.parseFloat(arg);
+            float floatArg = Float.parseFloat(argument);
             if (floatArg >= 0 && floatArg <= 1) {
                 return floatArg;
             } else {
                 getLogger().warning("Float argument out of range (0~1).");
             }
         } catch (NumberFormatException e) {
-            getLogger().warning(AreaSoundEvents.prefix + "Failed to parse float argument '" + arg + "'. " + e.getMessage());
+            getLogger().warning(AreaSoundEvents.prefix + "Failed to parse float argument '" + argument + "'. " + e.getMessage());
             getLogger().info(AreaSoundEvents.prefix + "It will be set with a default value: " + defaultValue);
             return defaultValue;
         }
@@ -42,13 +57,58 @@ public class Utils {
         return defaultValue;
     }
 
-    public static SoundCategory processSoundCategoryArgument(String value, SoundCategory defaultValue) {
+    public static int parseIntegerArgument(String argument, int defaultValue) {
+        try {
+            return Integer.parseInt(argument);
+        } catch (NumberFormatException e) {
+            getLogger().warning(AreaSoundEvents.prefix + "Failed to parse int argument '" + argument + "'. " + e.getMessage());
+            getLogger().info(AreaSoundEvents.prefix + "It will be set with a default value: " + defaultValue);
+            return defaultValue;
+        }
+    }
+
+    public static SoundCategory processSoundCategoryArgument(String argument, SoundCategory defaultValue) {
         for (SoundCategory soundCategory : SoundCategory.values()) {
-            if (soundCategory.name().equals(value.toUpperCase())) {
+            if (soundCategory.name().equals(argument.toUpperCase())) {
                 return soundCategory;
             }
         }
 
+        getLogger().warning(AreaSoundEvents.prefix + "Failed to get sound category argument '" + argument + "'.");
+        getLogger().info(AreaSoundEvents.prefix + "It will be set with a default value: " + defaultValue);
+
+        return defaultValue;
+    }
+
+    public static boolean parseBooleanArgument(String argument, boolean defaultValue) {
+        if (argument.equalsIgnoreCase("true")) {
+            return true;
+        } else if (argument.equalsIgnoreCase("false")) {
+            return false;
+        } else {
+            return defaultValue;
+        }
+    }
+
+    public static boolean getBooleanProperty(Map<String, Object> properties, String key, boolean defaultValue) {
+        Object value = properties.get(key);
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+
+        getLogger().info(AreaSoundEvents.prefix + "'" + key + "' has an invalid or missing value. Expected Boolean.");
+        getLogger().info(AreaSoundEvents.prefix + "'" + key + "' will be set with a default value: " + defaultValue);
+        return defaultValue;
+    }
+
+    public static Integer getIntegerProperty(Map<String, Object> properties, String key, int defaultValue) {
+        Object value = properties.get(key);
+        if (value instanceof Integer) {
+            return (Integer) value;
+        }
+
+        getLogger().info(AreaSoundEvents.prefix + "'" + key + "' has an invalid or missing value. Expected Integer.");
+        getLogger().info(AreaSoundEvents.prefix + "'" + key + "' will be set with a default value: " + defaultValue);
         return defaultValue;
     }
 
@@ -61,7 +121,7 @@ public class Utils {
         }
     }
 
-    public static  <T extends Enum<T>> T getEnumProperty(Map<String, Object> properties, String key, Class<T> enumClass, T defaultValue) {
+    public static <T extends Enum<T>> T getEnumProperty(Map<String, Object> properties, String key, Class<T> enumClass, T defaultValue) {
         Object value = properties.get(key);
         if (value instanceof String) {
             try {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,6 +31,16 @@ default-settings:
   # creating a new area sound event or the entry is incorrect
   default-sound-pitch: 1.0
 
+  # Default value for looping the sound, all your new region
+  # creations will have this value to allow loop or not
+  default-loop-sound: false
+
+  # Default value in SECONDS that the loop will reproduce the
+  # sound/music again. I highly recommend values upper 50 or 60,
+  # but is up to you how to use it. Very low values could affect
+  # the performance of your server and have unwanted effects.
+  default-loop-time: 60
+
   # (WIP) Default value that the sound will wait until playing from
   # the moment the player enters the area
   default-enter-cooldown: 0

--- a/src/main/resources/regions.yml
+++ b/src/main/resources/regions.yml
@@ -4,3 +4,5 @@ regions:
     source: MUSIC
     volume: 0.5
     pitch: 1
+    loop: false
+    loopTime: 60


### PR DESCRIPTION
- Added sound looping within a region.

/areasoundevents create <region-name> <sound-name> <source> <volume> <pitch> <loop [true/false]> <loop-time [60]>

If you set loop=true, the sound will be reproduced again once the loop-time is finished. The loop-time in SECONDS is the time until sound plays again.

IMPORTANT: You are free to add as few seconds as you want, but it could have an unwanted server cost. My recommendation of using this loop feature is to allow the loop for songs with more than 50 or 60 seconds. And finally, know the duration of your sound in seconds to correctly add it to the region's loop-time property, then you will have your sound playing again at the end of the current play.