### PR TITLE
Feature: Avoid name from saved yml and allow read the name from key value.

### DIFF
--- a/src/main/java/me/lavinytuttini/areasoundevents/settings/RegionsSettings.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/settings/RegionsSettings.java
@@ -11,6 +11,8 @@ import org.bukkit.SoundCategory;
 import org.bukkit.entity.Player;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.nodes.NodeTuple;
 import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Representer;
 
@@ -139,7 +141,7 @@ public class RegionsSettings {
             DumperOptions dumperOptions = new DumperOptions();
             dumperOptions.setPrettyFlow(true);
             dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-            Representer representer = new Representer(dumperOptions);
+            Representer representer = new CustomRepresenter(dumperOptions);
             representer.addClassTag(RegionData.class, Tag.MAP);
 
             if (!file.exists()) {
@@ -172,6 +174,21 @@ public class RegionsSettings {
             if (player != null) {
                 PlayerMessage.to(player).appendLine(localization.getString("region_settings_error_reload"), ChatColor.RED).send();
             }
+        }
+    }
+
+    static class CustomRepresenter extends Representer {
+        CustomRepresenter(DumperOptions options) {
+            super(options);
+            this.addClassTag(RegionData.class, Tag.MAP);
+        }
+
+        @Override
+        protected NodeTuple representJavaBeanProperty(Object javaBean, Property property, Object propertyValue, Tag customTag) {
+            if ("name".equals(property.getName())) {
+                return null;
+            }
+            return super.representJavaBeanProperty(javaBean, property, propertyValue, customTag);
         }
     }
 }


### PR DESCRIPTION
**Objective:** The objective is to exclude the name field from being serialized to YAML while still retaining it within the RegionData object for internal use.

**Implementation:** This is accomplished by extending the Representer class to create a custom representer called CustomRepresenter. Within this custom representer:

- Override the representJavaBeanProperty method to intercept the serialization process.
- In this method, we check if the property being processed is the name field.
- If it is the name field, we return null, effectively skipping it from the serialization process.
- If it's any other property, we delegate the serialization to the superclass method to handle it normally.

**Integration:** The CustomRepresenter is then used when creating the Yaml instance for dumping YAML data. By passing the CustomRepresenter to the Yaml constructor along with other options, we ensure that it's used for the serialization process.

**Result:** With this setup, when the save() method is called, the name field of RegionData objects will be excluded from the generated YAML output. However, the name field remains intact within the RegionData objects themselves for use within the application.