### PR TITLE
Improve play sound management for teleport, server join and respawn events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>me.lavinytuttini</groupId>
   <artifactId>areasoundevents</artifactId>
-  <version>1.4.1</version>
+  <version>1.4.2</version>
   <packaging>jar</packaging>
 
   <name>AreaSoundEvents</name>

--- a/src/main/java/me/lavinytuttini/areasoundevents/data/config/DefaultSettings.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/data/config/DefaultSettings.java
@@ -11,6 +11,7 @@ public class DefaultSettings {
     private int defaultListPageSize;
     private boolean defaultLoopSound;
     private int defaultSoundLoopTime;
+    private long defaultDelayPlaySound;
 
     public SoundCategory getDefaultSoundCategory() {
         return defaultSoundCategory;
@@ -74,5 +75,13 @@ public class DefaultSettings {
 
     public void setDefaultSoundLoopTime(int defaultSoundLoopTime) {
         this.defaultSoundLoopTime = defaultSoundLoopTime;
+    }
+
+    public long getDefaultDelayPlaySound() {
+        return defaultDelayPlaySound;
+    }
+
+    public void setDefaultDelayPlaySound(long defaultDelayPlaySound) {
+        this.defaultDelayPlaySound = defaultDelayPlaySound;
     }
 }

--- a/src/main/java/me/lavinytuttini/areasoundevents/listeners/PlayerListeners.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/listeners/PlayerListeners.java
@@ -3,9 +3,7 @@ package me.lavinytuttini.areasoundevents.listeners;
 import me.lavinytuttini.areasoundevents.managers.PlayerManager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerMoveEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.*;
 
 public class PlayerListeners implements Listener {
     private final PlayerManager playerManager = new PlayerManager();
@@ -24,4 +22,10 @@ public class PlayerListeners implements Listener {
     public void moveEvent(PlayerMoveEvent event) {
         playerManager.moveEvent(event.getPlayer());
     }
+
+    @EventHandler
+    public void teleportEvent(PlayerTeleportEvent event) { playerManager.teleportEvent((event.getPlayer())); }
+
+    @EventHandler
+    public void respawnEvent(PlayerRespawnEvent event) { playerManager.respawnEvent((event.getPlayer())); }
 }

--- a/src/main/java/me/lavinytuttini/areasoundevents/settings/ConfigSettings.java
+++ b/src/main/java/me/lavinytuttini/areasoundevents/settings/ConfigSettings.java
@@ -81,6 +81,7 @@ public class ConfigSettings {
         loadSetting(config, pathDefaultSettings + "default-list-page-size", Integer.class, defaultSettings::setDefaultListPageSize, 2);
         loadSetting(config, pathDefaultSettings + "default-loop-sound", Boolean.class, defaultSettings::setDefaultLoopSound, false);
         loadSetting(config, pathDefaultSettings + "default-loop-time", Integer.class, defaultSettings::setDefaultSoundLoopTime, 60);
+        loadSetting(config, pathDefaultSettings + "default-delay-play-sound", Long.class, defaultSettings::setDefaultDelayPlaySound, 5L);
     }
 
     private void loadDefaultSubcommandPermissions(FileConfiguration config) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -65,3 +65,9 @@ default-settings:
   # Default value to define the number of regions to display per
   # page in the /areasoundevents list command
   default-list-page-size: 2
+
+  # The delay that sound will be played when
+  # joining the server, respawning or teleporting
+  # Modify if sounds are not played in any of the above events
+  # The default value is 5 ticks (0.25s)
+  default-delay-play-sound: 5


### PR DESCRIPTION
- Added sound will play if the user is in a configured region when joining the server, being teleported, or respawning.
- Added sound will switch correctly if the user teleports between configured regions.
- Added sound is stopped when the user is teleported outside of a configured region.
- Added a new parameter (default-delay-play-sound) to adjust a delay when the music should be played when joining the server, being teleported and respawning. This parameter ensure that sound actions are executed correctly and at the right time, so I recommend using it with caution.